### PR TITLE
docs: 📝 fix yarn package install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 ```
 npm install react-static-clutch-embed static-clutch-embed
 pnpm install react-static-clutch-embed static-clutch-embed
-yarn install react-static-clutch-embed static-clutch-embed
+yarn add react-static-clutch-embed static-clutch-embed
 ```
 
 ## 📦 Packages 


### PR DESCRIPTION
Amazing job! ✨

One small detail tho - in yarn, you don't use `yarn install package-name`. `yarn install`/`yarn` is used to install all packages from `package.json`, whereas `yarn add` is equivalent to `npm install --save`.

vide: 
https://yarnpkg.com/cli/install
https://yarnpkg.com/cli/add